### PR TITLE
added dynamic deploys to netlify and robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "middleman-blog"
 # Middleman Deployment
 gem 'middleman-deploy', '~> 2.0.0.pre.alpha'
 
+# Robots txt
+gem 'middleman-robots'
+
 # Markdown engine
 gem 'kramdown'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     middleman-minify-html (3.4.1)
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
+    middleman-robots (1.3.3)
+      middleman (>= 4.0)
     minitest (5.11.3)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
@@ -138,10 +140,11 @@ DEPENDENCIES
   middleman-google-analytics
   middleman-livereload (~> 3.4)
   middleman-minify-html
+  middleman-robots
   string-urlize
   titleize
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/config.rb
+++ b/config.rb
@@ -133,9 +133,22 @@ end
 
 # Build-specific configuration
 configure :build do
-  config[:host] = "http://www.bivee.co"
+  config[:host] = "https://www.bivee.co"
   # For example, change the Compass output style for deployment
   # activate :minify_css
+
+  if ENV["CONTEXT"] == "staging"
+    activate :robots, 
+      rules: [
+        { user_agent: '*', disallow: %w[/] }
+      ]
+  else
+    activate :robots, 
+      rules: [
+        { user_agent: '*', allow: %w[/] }
+      ],
+      sitemap: 'https://www.bivee.co/sitemap.xml'
+  end
 
   # Minify Javascript on build
   # activate :minify_javascript

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,31 @@
+# Global settings applied to the whole site.  
+# 
+# “publish” is the directory to publish (relative to root of your repo),
+# “command” is your build command,
+# “base” is directory to change to before starting build. if you set base:
+#    that is where we will look for package.json/.nvmrc/etc not repo root!
+
+[build]
+  publish = "build"
+  command = "middleman build"
+
+# Production context: All deploys to the main
+# repository branch will inherit these settings.
+[context.production]
+  command = "middleman build"
+  [context.production.environment]
+    CONTEXT = "production"
+
+# Deploy Preview context: All Deploy Previews
+# will inherit these settings.
+[context.deploy-preview]
+  command = "middleman build"
+  [context.deploy-preview.environment]
+    CONTEXT = "production"
+
+# Branch Deploy context: All deploys that are not in
+# an active Deploy Preview will inherit these settings.
+[context.branch-deploy]
+  command = "middleman build"
+  [context.deploy-preview.environment]
+    CONTEXT = "production"


### PR DESCRIPTION
Netlify actually allows us to have inherent staging / dev based on branches we deploy to. 💃 Kinda awesome: 

**Details**: https://www.netlify.com/docs/continuous-deployment/

So staging--bivee.netlify.com should now be available. It generates a no-follow / disallow robots txt on anything not prod. 
