### PR TITLE
Cleaning up typography, layout widths, spacing, and color themes

### DIFF
--- a/data/case_studies.yml
+++ b/data/case_studies.yml
@@ -1,13 +1,13 @@
 headline:
   # the headline for the work section on the homepage
-  home: Has it worked? 
+  home: Has it worked?
   # the headline for the 'more work' nav at the bottom of each case study
   nav: More work
 
 # an intro blurb describing our work
-intro:  -| By applying design thinking to a bunch of situations (from relatively simple to super complex), 
-        across diverse sectors (healthcare, learning, disaster management, public-private partnerships, consumer products), 
-        for diverse needs (technology, innovation, knowledge management, branding, communications) 
+intro:  -| By applying design thinking to a bunch of situations (from relatively simple to super complex),
+        across diverse sectors (healthcare, learning, disaster management, public-private partnerships, consumer products),
+        for diverse needs (technology, innovation, knowledge management, branding, communications)
         we have helped our clients (ngos, corporates, international development organizations) do achieve better outcomes than they thought possible.
 
         Here's a taste of what we've done
@@ -15,8 +15,9 @@ intro:  -| By applying design thinking to a bunch of situations (from relatively
 # the list of projects and their metadata
 # -> used to construct pages for each case study, based on 'project' template and markdown files in 'work' folders
 projects:
-- short_title: PPP Knowledge Lab
-  long_title: Knowledge Sharing for Public Private Partnerships
+- title:
+    long: Knowledge Sharing for Public Private Partnerships
+    short: PPP Knowledge Lab
   slug: PPP
   client:
     name: World Bank PPP Group
@@ -26,16 +27,13 @@ projects:
   cover:
     thumb: work/ppp/assets/ppp-thumb.png
     full_size: work/ppp/assets/ppp-cover.png
-  team:
-    - Helly Stoyanova
-    - Scott Schaffter
-    - Nicholas Kingston
-    - Jay Perry
 
-- short_title: Gateway Academy
-  long_title: eLearning for Financial Inclusion
+- title:
+    long: eLearning for Financial Inclusion
+    short: Gateway Academy
+    subtitle: Gateway Academy
   slug: GA
-  client: 
+  client:
     name: CGAP and Mastercard Foundation
     logo: work/ga/assets/logo-cgap.svg
   date: 2017+
@@ -43,18 +41,13 @@ projects:
   cover:
     thumb: work/ga/assets/ga-thumb.png
     full_size: work/ppp/assets/ppp-cover.png
-  team:
-    - Helly Stoyanova
-    - Scott Schaffter
-    - Nicholas Kingston
-    - Jay Perry
-    - Nestor Fuentes
-    - Haley Cline
-    
-- short_title: Development Data Hub
-  long_title: Strategy for Data Sharing
+
+- title:
+    long: Strategy for Data Sharing
+    short: Development Data Hub
+    subtitle: Development Data Hub
   slug: DDH
-  client: 
+  client:
     name: World Bank Group
     logo: work/ddh/assets/logo-wbg.svg
   date: 2015
@@ -62,8 +55,3 @@ projects:
   cover:
     thumb: work/ddh/assets/ddh-thumb.png
     full_size: work/ppp/assets/ppp-cover.png
-  team:
-    - Scott Schaffter
-    - Nicholas Kingston
-    - Jay Perry
-    - Haley Cline

--- a/data/case_studies.yml
+++ b/data/case_studies.yml
@@ -14,9 +14,12 @@ intro:  -| By applying design thinking to a bunch of situations (from relatively
 
 # the list of projects and their metadata
 # -> used to construct pages for each case study, based on 'project' template and markdown files in 'work' folders
+# -> title.long is the main headline for the case study, and should be descriptive/editorial
+# -> title.short is a short version of the title used to refer to the project in the UI/navigation. Usually just the project name (e.g. PPP Knowledge Lab) is good.
+# -> title.subtitle is a descriptive/editorial subhead that should be displayed on the case study page. This is helpful if the client logo and long title don't make the project name obvious.
 projects:
 - title:
-    long: Knowledge Sharing for Public Private Partnerships
+    long: Knowledge sharing for public private partnerships
     short: PPP Knowledge Lab
   slug: PPP
   client:
@@ -29,7 +32,7 @@ projects:
     full_size: work/ppp/assets/ppp-cover.png
 
 - title:
-    long: eLearning for Financial Inclusion
+    long: e-Learning for financial inclusion
     short: Gateway Academy
     subtitle: Gateway Academy
   slug: GA
@@ -43,7 +46,7 @@ projects:
     full_size: work/ppp/assets/ppp-cover.png
 
 - title:
-    long: Strategy for Data Sharing
+    long: A strategy for data sharing
     short: Development Data Hub
     subtitle: Development Data Hub
   slug: DDH

--- a/source/assets/stylesheets/base/_html.scss
+++ b/source/assets/stylesheets/base/_html.scss
@@ -16,6 +16,10 @@ html {
   @include media('>medium') {
     font-size: 120%;
   }
+
+  @include media('>large') {
+    font-size: 125%;
+  }
 }
 
 *,

--- a/source/assets/stylesheets/base/_html.scss
+++ b/source/assets/stylesheets/base/_html.scss
@@ -7,7 +7,11 @@
 
 html {
   box-sizing: border-box;
-  font-size: 100%;
+  font-size: 90%;
+
+  @include media('>xsmall') {
+    font-size: 100%;
+  }
 
   @include media('>small') {
     font-size: 110%;

--- a/source/assets/stylesheets/base/_html.scss
+++ b/source/assets/stylesheets/base/_html.scss
@@ -10,11 +10,11 @@ html {
   font-size: 100%;
 
   @include media('>small') {
-    font-size: 105%;
+    font-size: 110%;
   }
 
   @include media('>medium') {
-    font-size: 110%;
+    font-size: 120%;
   }
 }
 

--- a/source/assets/stylesheets/base/_type.scss
+++ b/source/assets/stylesheets/base/_type.scss
@@ -82,11 +82,13 @@ h3,
 h4,
 .t-scale-delta {
   @include type-fluid($size-min: 'epsilon', $size-max: 'delta');
+  letter-spacing: -0.02em;
 }
 
 h5,
 .t-scale-epsilon {
   font-size: scale-type('epsilon');
+  letter-spacing: -0.005em;
 }
 
 h6,

--- a/source/assets/stylesheets/base/_type.scss
+++ b/source/assets/stylesheets/base/_type.scss
@@ -109,7 +109,7 @@ body {
 }
 
 p {
-  @include color('text' 'secondary');
+  @include color('text' 'primary');
   font-size: scale-type('epsilon');
 
   margin: 0;
@@ -209,6 +209,7 @@ cite {
 // -----------------------------------------------------------------------------
 
 .t-content {
+  @include color('text' 'primary');
 
   // add a line of whitespace between everything
   > * + * {

--- a/source/assets/stylesheets/components/_button.scss
+++ b/source/assets/stylesheets/components/_button.scss
@@ -25,7 +25,7 @@ $button-icon-margin: ms(1, 1em);
   box-shadow: none;
   cursor: pointer;
   display: inline-block;
-  font-size: scale-type('epsilon');
+  font-size: scale-type('zeta');
   padding: ms(-2, 1em) ms(3, 1em);
   position: relative;
   text-shadow: none;
@@ -75,5 +75,5 @@ $button-icon-margin: ms(1, 1em);
 }
 
 [data-ui-button~='large'] {
-  font-size: scale-type('delta');
+  font-size: scale-type('epsilon');
 }

--- a/source/assets/stylesheets/components/_button.scss
+++ b/source/assets/stylesheets/components/_button.scss
@@ -17,7 +17,7 @@ $button-icon-margin: ms(1, 1em);
 
 [data-ui-button] {
   @include border-radius($size: 'large');
-  @include border($color: 'highlight');
+  @include border($color: 'accent');
   @include color('text' 'primary');
   @include font-display('bold');
   @include transition;

--- a/source/assets/stylesheets/components/_gallery.scss
+++ b/source/assets/stylesheets/components/_gallery.scss
@@ -62,12 +62,14 @@ $gallery-gutter: space();
   display: block;
   font-size: $type-size-default;
   margin: 0;
+  width: 100%;
   padding: ($gallery-gutter / 2);
   position: relative;
   vertical-align: top;
 
   @supports (display: flex) {
     display: flex;
+    flex-direction: column;
   }
 
   @include gallery-item(300px);

--- a/source/assets/stylesheets/components/_gallery.scss
+++ b/source/assets/stylesheets/components/_gallery.scss
@@ -62,10 +62,10 @@ $gallery-gutter: space();
   display: block;
   font-size: $type-size-default;
   margin: 0;
-  width: 100%;
   padding: ($gallery-gutter / 2);
   position: relative;
   vertical-align: top;
+  width: 100%;
 
   @supports (display: flex) {
     display: flex;

--- a/source/assets/stylesheets/config/_color.scss
+++ b/source/assets/stylesheets/config/_color.scss
@@ -11,8 +11,7 @@
 // -> PRIVATE, do not use outside this settings file
 
 // neutrals
-$blue-kuri: #9fa0ae;
-$blue-kuri-dark: #464c56;
+$blue-kuri: #9698B1;
 $blackberry: #263750;
 
 // highlights
@@ -37,40 +36,40 @@ $themes: (
   'default': (
     'text': (
       'primary': $blackberry,
-      'secondary': $blue-kuri-dark,
-      'tertiary': $blue-kuri
+      'secondary': shade($blue-kuri, 10),
+      'tertiary': tint($blue-kuri, 10)
     ),
     'bg': #fff,
-    'well': lighten($blue-kuri, 31),
+    'well': tint($blue-kuri, 92),
     'shadow': shade($blue-kuri, 15),
-    'border': lighten($blue-kuri, 20),
-    'highlight': highlight('blueberry'),
-    'accent': highlight('raspberry')
+    'border': tint($blue-kuri, 60),
+    'highlight': highlight('raspberry'),
+    'accent': highlight('blueberry')
   ),
   'dark': (
     'text': (
       'primary': #fff,
-      'secondary': lighten($blackberry, 65),
-      'tertiary': lighten($blackberry, 20)
+      'secondary': tint($blackberry, 70),
+      'tertiary': tint($blackberry, 45)
     ),
     'bg': $blackberry,
     'well': darken($blackberry, 7),
     'shadow': shade($blackberry, 15),
     'border': darken($blackberry, 15),
-    'highlight': highlight('blueberry'),
-    'accent': highlight('raspberry')
+    'highlight': highlight('raspberry'),
+    'accent': highlight('blueberry')
   ),
   'midtone': (
     'text': (
       'primary': #fff,
-      'secondary': $blackberry,
-      'tertiary': $blackberry
+      'secondary': shade($blackberry, 10),
+      'tertiary': shade($blue-kuri, 40)
     ),
     'bg': $blue-kuri,
     'well': darken($blue-kuri, 5),
     'shadow': shade($blue-kuri, 15),
     'border': darken($blue-kuri, 10),
-    'highlight': highlight('orange'),
+    'highlight': #FFC60C,
     'accent': $blackberry
   )
 );
@@ -239,7 +238,7 @@ $focus-default: 10;
 @mixin theme($theme) {
   background-color: color('bg', $theme);
   border-color: color('border', $theme);
-  color: color('text' 'secondary', $theme);
+  color: color('text' 'primary', $theme);
 
   // highlight color when you select something
   ::selection {

--- a/source/assets/stylesheets/config/_color.scss
+++ b/source/assets/stylesheets/config/_color.scss
@@ -11,7 +11,7 @@
 // -> PRIVATE, do not use outside this settings file
 
 // neutrals
-$blue-kuri: #9698B1;
+$blue-kuri: #9698b1;
 $blackberry: #263750;
 
 // highlights
@@ -69,7 +69,7 @@ $themes: (
     'well': darken($blue-kuri, 5),
     'shadow': shade($blue-kuri, 15),
     'border': darken($blue-kuri, 10),
-    'highlight': #FFC60C,
+    'highlight': #ffc60c,
     'accent': $blackberry
   )
 );

--- a/source/assets/stylesheets/config/_layout_width.scss
+++ b/source/assets/stylesheets/config/_layout_width.scss
@@ -5,10 +5,10 @@
 
 // width of main layout
 $layout-widths: (
-  'xnarrow': 480px,
-  'narrow': 600px,
-  'default': 750px,
-  'wide': 1200px
+  'xnarrow': 30rem,
+  'narrow': 37.5rem,
+  'default': 48rem,
+  'wide': 75rem
 );
 
 // Getter function for layout widths

--- a/source/assets/stylesheets/config/_layout_width.scss
+++ b/source/assets/stylesheets/config/_layout_width.scss
@@ -6,7 +6,7 @@
 // width of main layout
 $layout-widths: (
   'xnarrow': 30rem,
-  'narrow': 36rem,
+  'narrow': 37rem,
   'default': 48rem,
   'wide': 72rem
 );

--- a/source/assets/stylesheets/config/_layout_width.scss
+++ b/source/assets/stylesheets/config/_layout_width.scss
@@ -6,9 +6,9 @@
 // width of main layout
 $layout-widths: (
   'xnarrow': 30rem,
-  'narrow': 37.5rem,
+  'narrow': 36rem,
   'default': 48rem,
-  'wide': 75rem
+  'wide': 72rem
 );
 
 // Getter function for layout widths

--- a/source/assets/stylesheets/config/_scale.scss
+++ b/source/assets/stylesheets/config/_scale.scss
@@ -23,13 +23,13 @@ $scale-base-type: 16px;
 // -> we could compute this via the modular scale mixins,
 // -> but doing it by hand allows us to tweak certain sizes to suit the fonts we're using
 $scale-type: (
-  'alpha': convert-to-rem(57px),
-  'beta': convert-to-rem(39px),
-  'gamma': convert-to-rem(28px),
-  'delta': convert-to-rem(23px),
-  'epsilon': convert-to-rem(16px),
-  'zeta': convert-to-rem(13px),
-  'eta': convert-to-rem(11px)
+  'alpha': 3.7rem,
+  'beta': 2.5rem,
+  'gamma': 2rem,
+  'delta': 1.44rem,
+  'epsilon': 1.2rem,
+  'zeta': 1rem,
+  'eta': 0.8rem
 ) !default;
 
 @function scale-type($size) {

--- a/source/assets/stylesheets/config/_type.scss
+++ b/source/assets/stylesheets/config/_type.scss
@@ -86,7 +86,7 @@ $type-leading: (
 // -> body font
 
 // use @import for the moment, having trouble creating webfonts with Source Sans
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,700,700i');
 // @include font-face('source-sans-normal-normal', $file-path: '#{$asset-path-fonts}/Aspira-Thin-webfont', $file-formats: woff woff2) {
 //   @include font-display;
 // }
@@ -107,26 +107,36 @@ $type-leading: (
 // ----- Cairo -----------------------------------------------------------------
 // -> display font
 
-@include font-face('cairo-normal', $file-path: '#{$asset-path-fonts}/cairo/cairo-regular-webfont', $file-formats: eot woff) {
-  @include font-display;
-}
-@include font-face('cairo-light', $file-path: '#{$asset-path-fonts}/cairo/cairo-light-webfont', $file-formats: eot woff) {
-  @include font-display;
-  font-weight: normal;
-}
-@include font-face('cairo-bold', $file-path: '#{$asset-path-fonts}/cairo/cairo-bold-webfont', $file-formats: eot woff) {
-  @include font-display;
-  font-weight: bold;
-}
+
+@import url('https://fonts.googleapis.com/css?family=Cairo:300,400,600');
+// @include font-face('cairo-normal', $file-path: '#{$asset-path-fonts}/cairo/cairo-regular-webfont', $file-formats: eot woff) {
+//   @include font-display;
+// }
+// @include font-face('cairo-light', $file-path: '#{$asset-path-fonts}/cairo/cairo-light-webfont', $file-formats: eot woff) {
+//   @include font-display;
+//   font-weight: normal;
+// }
+// @include font-face('cairo-bold', $file-path: '#{$asset-path-fonts}/cairo/cairo-bold-webfont', $file-formats: eot woff) {
+//   @include font-display;
+//   font-weight: bold;
+// }
 
 
 // Font mixins
 // -----------------------------------------------------------------------------
 // -> PUBLIC, use these to style type globally & in modules
 
-@mixin font-display($weight: normal) {
-  font-family: 'cairo-#{$weight}', $font-stack-verdana;
-  font-weight: unquote(if($weight == light, normal, $weight));
+@mixin font-display($weight: light) {
+  font-family: 'Cairo', $font-stack-verdana;
+  @if $weight == 'light' {
+    font-weight: 300;
+  } @elseif $weight == 'bold' {
+    font-weight: 600;
+  } @else {
+    font-weight: 400;
+  }
+  // font-family: 'cairo-#{$weight}', $font-stack-verdana;
+  // font-weight: unquote(if($weight == light, normal, $weight));
 }
 
 @mixin font-body($weight: normal, $style: normal) {

--- a/source/assets/stylesheets/config/_type.scss
+++ b/source/assets/stylesheets/config/_type.scss
@@ -142,7 +142,7 @@ $type-leading: (
 @mixin font-body($weight: normal, $style: normal) {
   font-family: 'Source Sans Pro', $font-stack-verdana;
   // font-family: 'source-sans-#{$weight}-#{$style}', $verdana;
-  font-weight: if($weight == normal, 400, 700);
+  font-weight: if($weight == normal, 300, 700);
   @if $style != normal {
     font-style: unquote($style);
   }

--- a/source/case_study.html.erb
+++ b/source/case_study.html.erb
@@ -5,11 +5,15 @@
   <header class="padding-x-wide padding-top-xwide padding-bottom-wide border-bottom c-theme-dark">
     <% component 'wrapper', locals: { width: 'wide', classes: 't-align-center' } do %>
       <%= image_tag project.client.logo, alt: project.client.name, style: 'max-width: 16em; max-height: 12em;' %>
-      <h1 class="padding-top-wide padding-bottom-narrow"><%= project.long_title %></h1>
-      <p class="t-heading t-scale-gamma c-highlight padding-bottom"><%= project.short_title %></p>
-      <p data-ui-gutter="flush narrow" class="t-heading t-scale-epsilon c-text-secondary">
-        <time data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="padding-right-xnarrow border-right"><%= project.date %></span></time><span data-ui-gutter-item class="display-inline-block"><%= project.type %></span>
-      </p>
+      <h1 class="padding-top-wide"><%= project.title.long %></h1>
+      <% if project.title.subtitle %>
+        <p class="t-heading t-scale-beta c-highlight padding-top-narrow"><%= project.title.subtitle %></p>
+      <% end %>
+      <div class="padding-top">
+        <p data-ui-gutter="flush narrow" class="t-heading t-scale-epsilon c-text-secondary">
+          <time data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="padding-right-xnarrow border-right"><%= project.date %></span></time><span data-ui-gutter-item class="display-inline-block"><%= project.type %></span>
+        </p>
+      </div>
       <a class="display-inline-block margin-top-wide" href="#main_content">
         <%= component 'icon', locals: { id: 'arrow-down' } %>
       </a>
@@ -18,7 +22,7 @@
 
   <!-- Main content: sections -->
   <main id="main_content">
-    <% sections = sitemap.resources.select {|r| r.data.project == project.slug || r.data.project == project.short_title }.sort_by {|r| r.data.weight } %>
+    <% sections = sitemap.resources.select {|r| r.data.project == project.slug || r.data.project == project.title.short }.sort_by {|r| r.data.weight } %>
     <% sections.each do |section| %>
       <% component 'panel', locals: { slug: false } do %>
         <% component 'wrapper', locals: { width: 'narrow' } do %>

--- a/source/case_study.html.erb
+++ b/source/case_study.html.erb
@@ -4,7 +4,7 @@
   <!-- Cover image, and title -->
   <header class="padding-x-wide padding-top-xwide padding-bottom-wide border-bottom c-theme-dark">
     <% component 'wrapper', locals: { width: 'wide', classes: 't-align-center' } do %>
-      <%= image_tag project.client.logo, alt: project.client.name, style: 'max-width: 16em; max-height: 12em;' %>
+      <%= image_tag project.client.logo, alt: project.client.name, style: 'max-width: 13em; max-height: 12em;' %>
       <h1 class="padding-top-wide"><%= project.title.long %></h1>
       <% if project.title.subtitle %>
         <p class="t-heading t-scale-beta c-highlight padding-top-narrow"><%= project.title.subtitle %></p>

--- a/source/components/_button_link.erb
+++ b/source/components/_button_link.erb
@@ -17,7 +17,7 @@
   ]
 %>
 
-<% link_to url, data: { 'ui-button': props.empty? ? props.join(' ') : '' }, class: classes do %>
+<% link_to url, data: { 'ui-button': props.empty? ? '' : props.join(' ') }, class: classes do %>
   <%= component("icon", locals: { id: icon, parent: 'data-ui-button-icon' }) if icon && icon_position == 'left' %>
   <%= label %>
   <%= component("icon", locals: { id: icon, parent: 'data-ui-button-icon' }) if icon && icon_position == 'right' %>

--- a/source/components/_case_studies_list.erb
+++ b/source/components/_case_studies_list.erb
@@ -11,17 +11,17 @@
 
 <ul data-ui-gallery="large centered" <%= " class='#{classes}'" if classes %>>
   <% projects.each do |project| %>
-    <% unless project.slug == exclude || project.short_title == exclude %>
+    <% unless project.slug == exclude || project.title.short == exclude %>
       <li data-ui-gallery-item>
         <% link_to "/work/#{project.slug.urlize}/", class: 'display-flex-fill display-block border border-round c-bg' do %>
           <%= component 'fluid_aspect_image', locals: {
             source: project.cover.thumb,
             bg_size: 'cover',
-            alt: project.short_title
+            alt: project.title.short
           } %>
           <div class="padding-narrow border-top">
-            <h2 class="t-scale-delta"><%= project.slug %></h2>
-            <p class="t-heading t-scale-zeta padding-top-xxnarrow c-text-secondary"><%= project.client.name %></p>
+            <h2 class="t-scale-delta"><%= project.title.short %></h2>
+            <p class="t-scale-zeta padding-top-xxnarrow c-text-secondary"><%= project.client.name %></p>
           </div>
         <% end %>
       </li>

--- a/source/components/_case_studies_list.erb
+++ b/source/components/_case_studies_list.erb
@@ -20,7 +20,7 @@
             alt: project.short_title
           } %>
           <div class="padding-narrow border-top">
-            <h2 class="t-scale-delta"><%= project.short_title %></h2>
+            <h2 class="t-scale-delta"><%= project.slug %></h2>
             <p class="t-heading t-scale-zeta padding-top-xxnarrow c-text-secondary"><%= project.client.name %></p>
           </div>
         <% end %>

--- a/source/components/_main_footer.erb
+++ b/source/components/_main_footer.erb
@@ -6,7 +6,7 @@
 <!-- Contact us -->
 <% component 'panel', locals: { theme: 'dark' } do %>
   <% component 'wrapper', locals: { width: 'narrow' } do %>
-    <h1 class="t-align-center padding-bottom"><%= data.site.contact.headline %></h1>
+    <h1 class="t-scale-beta t-align-center padding-bottom"><%= data.site.contact.headline %></h1>
      <p class="t-content"><%= data.site.contact.intro %></p>
 
     <ul class="list-undecorated padding-top">
@@ -27,17 +27,17 @@
             <div data-ui-gutter-item class="display-inline-block">
               <%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}" } %>
             </div>
-            <p data-ui-gutter-item class="display-inline-block"><%= data.site.contact.email %></p>
+            <p data-ui-gutter-item class="display-inline-block t-scale-zeta"><%= data.site.contact.email %></p>
           </div>
         </div>
         <!-- Social channels -->
         <div data-ui-bookend-item="right" data-ui-gutter-item>
           <div data-ui-gutter="flush xxnarrow">
-            <h2 data-ui-gutter-item class="t-font-body t-scale-epsilon c-text-tertiary display-inline-block">Say hi:</h2>
+            <h2 data-ui-gutter-item class="t-font-body t-scale-zeta c-text-tertiary display-inline-block">Say hi:</h2>
             <ul data-ui-gutter-item class="list-inline display-inline-block">
               <% data.site.contact.social.each do |channel| %>
               <li class="list-inline-item padding-x-between-xxnarrow">
-                <% link_to channel.url, class: 'c-text-primary', target: '_blank', title: "Say hi on #{channel.name}" do %>
+                <% link_to channel.url, class: 'c-text-primary t-scale-zeta', target: '_blank', title: "Say hi on #{channel.name}" do %>
                   <% component 'icon', locals: { id: channel.icon, title: channel.name, role: 'img' } %>
                 <% end %>
               </li>

--- a/source/components/_main_footer.erb
+++ b/source/components/_main_footer.erb
@@ -12,7 +12,7 @@
     <ul class="list-undecorated padding-top">
       <% data.site.contact.locations.each_with_index do |location, index| %>
         <li class="margin-y-between">
-          <h2 class="t-scale-delta padding-bottom-xxnarrow c-highlight"><%= location.name %></h2>
+          <h2 class="t-scale-delta padding-bottom-xxnarrow c-accent"><%= location.name %></h2>
           <p><%= location.address %></p>
         </li>
       <% end %>
@@ -27,13 +27,13 @@
             <div data-ui-gutter-item class="display-inline-block">
               <%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}" } %>
             </div>
-            <p data-ui-gutter-item class="display-inline-block t-scale-zeta"><%= data.site.contact.email %></p>
+            <p data-ui-gutter-item class="display-inline-block t-scale-zeta c-text-secondary"><%= data.site.contact.email %></p>
           </div>
         </div>
         <!-- Social channels -->
         <div data-ui-bookend-item="right" data-ui-gutter-item>
           <div data-ui-gutter="flush xxnarrow">
-            <h2 data-ui-gutter-item class="t-font-body t-scale-zeta c-text-tertiary display-inline-block">Say hi:</h2>
+            <h2 data-ui-gutter-item class="t-font-body t-scale-zeta c-text-secondary display-inline-block">Say hi:</h2>
             <ul data-ui-gutter-item class="list-inline display-inline-block">
               <% data.site.contact.social.each do |channel| %>
               <li class="list-inline-item padding-x-between-xxnarrow">

--- a/source/components/_main_footer.erb
+++ b/source/components/_main_footer.erb
@@ -23,17 +23,21 @@
       <div data-ui-bookend="horizontal@small" data-ui-gutter="flush">
         <div data-ui-bookend-item="left" data-ui-gutter-item>
           <div data-ui-gutter="flush narrow">
-            <div data-ui-gutter-item class="display-inline-block"><%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}" } %></div>
+            <!-- Email button -->
+            <div data-ui-gutter-item class="display-inline-block">
+              <%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}" } %>
+            </div>
             <p data-ui-gutter-item class="display-inline-block"><%= data.site.contact.email %></p>
           </div>
         </div>
+        <!-- Social channels -->
         <div data-ui-bookend-item="right" data-ui-gutter-item>
           <div data-ui-gutter="flush xxnarrow">
             <h2 data-ui-gutter-item class="t-font-body t-scale-epsilon c-text-tertiary display-inline-block">Say hi:</h2>
             <ul data-ui-gutter-item class="list-inline display-inline-block">
               <% data.site.contact.social.each do |channel| %>
               <li class="list-inline-item padding-x-between-xxnarrow">
-                <% link_to channel.url, target: '_blank', title: "Say hi on #{channel.name}" do %>
+                <% link_to channel.url, class: 'c-text-primary', target: '_blank', title: "Say hi on #{channel.name}" do %>
                   <% component 'icon', locals: { id: channel.icon, title: channel.name, role: 'img' } %>
                 <% end %>
               </li>

--- a/source/components/_main_header.erb
+++ b/source/components/_main_header.erb
@@ -34,7 +34,7 @@
       <div data-ui-bookend-item="left">
         <% link_to back, class: 'display-inline-block c-text-secondary t-scale-zeta' do %>
           <%= component 'icon', locals: { id: 'arrow-left', space: 'right' } %>
-          <span class="t-font-display t-weight-bold">Home</span>
+          <span class="t-font-display">Home</span>
         <% end %>
       </div>
     <% end %>

--- a/source/layouts/staff_profile.html.erb
+++ b/source/layouts/staff_profile.html.erb
@@ -12,11 +12,9 @@
       <%= component 'feature_image', locals: { source: "portraits/#{current_page.data.portrait.full_size}", alt: current_page.data.name } %>
       <header class="padding-bottom t-align-center">
   	    <h1 class="t-scale-alpha"><%= current_page.data.name %></h1>
-  	    <div class="padding-top-xnarrow">
-          <p data-ui-gutter="narrow flush" class="t-heading t-scale-delta c-highlight padding-top-xnarrow">
-            <% unless current_page.data.role.level == 'Team' %><span data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="display-inline-block padding-right-narrow border-right"><%= current_page.data.role.level %></span></span><% end %><span data-ui-gutter-item class="display-inline-block"><%= current_page.data.role.title %></span>
-          </p>
-        </div>
+        <p data-ui-gutter="xnarrow" class="t-heading t-scale-delta c-accent">
+          <% unless current_page.data.role.level == 'Team' %><span data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="display-inline-block padding-right-xnarrow border-right"><%= current_page.data.role.level %></span></span><% end %><span data-ui-gutter-item class="display-inline-block"><%= current_page.data.role.title %></span>
+        </p>
     	</header>
       <%= yield %>
     <% end %>

--- a/source/layouts/staff_profile.html.erb
+++ b/source/layouts/staff_profile.html.erb
@@ -12,9 +12,11 @@
       <%= component 'feature_image', locals: { source: "portraits/#{current_page.data.portrait.full_size}", alt: current_page.data.name } %>
       <header class="padding-bottom t-align-center">
   	    <h1 class="t-scale-alpha"><%= current_page.data.name %></h1>
-  	    <p data-ui-gutter="narrow" class="t-heading c-highlight padding-top-xnarrow">
-          <% unless current_page.data.role.level == 'Team' %><span data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="padding-right-xnarrow border-right"><%= current_page.data.role.level %></span></span><% end %><span data-ui-gutter-item class="display-inline-block"><%= current_page.data.role.title %></span>
-        </p>
+  	    <div class="padding-top-xnarrow">
+          <p data-ui-gutter="narrow flush" class="t-heading t-scale-delta c-highlight padding-top-xnarrow">
+            <% unless current_page.data.role.level == 'Team' %><span data-ui-gutter-item class="display-inline-block t-weight-bold"><span class="display-inline-block padding-right-narrow border-right"><%= current_page.data.role.level %></span></span><% end %><span data-ui-gutter-item class="display-inline-block"><%= current_page.data.role.title %></span>
+          </p>
+        </div>
     	</header>
       <%= yield %>
     <% end %>


### PR DESCRIPTION
## Description
- made body type larger; bumped the `epsilon` type size up to ~19px rather than 16px
- bumped root type size on the `body` tag at various breakpoints; it starts at 95% on small phones and goes up to 125% on large displays. This affects anything using `rem` units.
- decided to set layout widths of the `wrapper` component in `rem` units instead of pixels. I haven't tried this before but it seems helpful here - if the live area widens as the root type size increases it means line measures stay roughly the same and we get less awkward line breaks on larger screens. I like this so far - going to start doing it this way from now on I think.
- set default body type in a lighter weight of Source Sans, which feels better at larger sizes. It's a touch thin but looks great on retina, and is acceptable on normal res displays (or at least the one on my desk).
- massaged color palette and adjusted color roles in each theme so everything generally plays better together and there's a more contrast. the gray-purple color we use in the midtone theme I made darker and more purplish than grayish, so it feels better with the orange highlights and generally a bit more lively/less muddy.
- cleaned up case study metadata in `case_studies.yml` and corrected some typos/capitalization errors.
- addressed a bunch of the feedback from Nestor in the PDF he marked up and posted to Slack.

## Issues
- Resolves #46 
- Resolves #42