### PR TITLE
Case study feature images

### DIFF
--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -6,6 +6,30 @@
 @import '../config/layout_width';
 @import '../config/spacing';
 
+// create overrides for an 'outcrop' version of the wrapper at a given width
+// -> see 'outcrop' styles below
+
+@function not-wrapper-variation() {
+  $list: null;
+
+  @each $name, $width in $layout-widths {
+    @if $name != 'default' {
+      $list: append($list, #{'&:not([data-ui-wrapper~="#{$name}"])'}, 'comma');
+    }
+  }
+
+  @return $list;
+}
+
+@mixin wrapper-outcrop-variation($width, $parent-width: 'default') {
+  $margin: if(layout-w-difference($parent-width, $width) < 0, (layout-w-difference($parent-width, $width) / 2), auto);
+  left: 0;
+  margin-left: $margin;
+  margin-right: $margin;
+  right: 0;
+  width: if(layout-w-difference($parent-width, $width) > 0, layout-w($width), auto);
+}
+
 // Block
 // -----------------------------------------------------------------------------
 
@@ -26,8 +50,7 @@
 }
 
 // a child element of a layout wrapper which is actually wider than its parent
-// -> use to expand a child of a default wrapper to the width of a 'wide' wrapper
-// -> great trick stolen from CSS-Tricks: https://css-tricks.com/full-width-containers-limited-width-parents/
+// -> a great trick from CSS-Tricks: https://css-tricks.com/full-width-containers-limited-width-parents/
 [data-ui-wrapper~='outcrop'] {
   display: block;
   left: 50%;
@@ -39,11 +62,47 @@
   right: 50%;
   width: 100vw;
 
-  @include media('>#{layout-w(wide)}') {
-    left: 0;
-    margin-left: ((layout-w() - layout-w('wide')) / 2);
-    margin-right: ((layout-w() - layout-w('wide')) / 2);
-    right: 0;
-    width: auto;
+  // if nested in a default wrapper
+  // -> in this case both are the same width, so just kill everything
+  [data-ui-wrapper] & {
+    // width: auto;
+    // margin-left: 0;
+    // margin-right: 0;
+    // left: 0;
+    // right: 0;
+
+    // if a specific width is nested in a default wrapper
+    @each $name, $width in $layout-widths {
+      @include media('>#{$width}') {
+        @if ($name != 'default') {
+          &[data-ui-wrapper~='#{$name}'] {
+            @include wrapper-outcrop-variation($name);
+          }
+        }
+      }
+    }
+  }
+
+  // if nested in a parent with a specific width
+  // -> e.g. [data-ui-wrapper~='narrow'] [data-ui-wrapper~='outcrop'] {...}
+  //    or [data-ui-wrapper~='narrow'] [data-ui-wrapper~='wide'][data-ui-wrapper~='outcrop'] {...}
+  @each $parent-name, $parent-width in $layout-widths {
+    @if ($parent-name != 'default') {
+      [data-ui-wrapper~='#{$parent-name}'] & {
+        @each $child-name, $child-width in $layout-widths {
+          @include media('>#{$child-width}') {
+            @if($child-name == 'default') {
+              #{not-wrapper-variation()} {
+                @include wrapper-outcrop-variation($child-name, $parent-name);
+              }
+            } @else {
+              &[data-ui-wrapper~='#{$child-name}'] {
+                @include wrapper-outcrop-variation($child-name, $parent-name);
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -6,28 +6,29 @@
 @import '../config/layout_width';
 @import '../config/spacing';
 
-// create overrides for an 'outcrop' version of the wrapper at a given width
-// -> see 'outcrop' styles below
-
-@function not-wrapper-variation() {
-  $list: null;
-
-  @each $name, $width in $layout-widths {
-    @if $name != 'default' {
-      $list: append($list, #{'&:not([data-ui-wrapper~="#{$name}"])'}, 'comma');
-    }
-  }
-
-  @return $list;
+// create a selector list that includes all wrapper width variations with :not()
+// -> this addresses a specificity issue where [data-ui-wrapper~='outcrop'] selects
+//    all sizes, but we need to select only the 'default' size
+// -> can't find a way to automatically build this selector from the $layout-widths map,
+//    so have to hard code this for the moment. Update when new global widths are added to config.
+@function _not-wrapper-variation() {
+  @return #{&:not([data-ui-wrapper~='narrow']):not([data-ui-wrapper~='wide'])};
 }
 
-@mixin wrapper-outcrop-variation($width, $parent-width: 'default') {
+// create overrides for an 'outcrop' version of the wrapper at a given width
+// -> see 'outcrop' styles below
+@mixin _wrapper-outcrop-variation($width, $parent-width: 'default', $padding: 'none') {
   $margin: if(layout-w-difference($parent-width, $width) < 0, (layout-w-difference($parent-width, $width) / 2), auto);
   left: 0;
   margin-left: $margin;
   margin-right: $margin;
   right: 0;
   width: if(layout-w-difference($parent-width, $width) > 0, layout-w($width), auto);
+
+  @if $padding != 'none' {
+    padding-left: if(type-of($padding) == 'string', space($padding), $padding);
+    padding-right: if(type-of($padding) == 'string', space($padding), $padding);
+  }
 }
 
 // Block
@@ -65,18 +66,25 @@
   // if nested in a default wrapper
   // -> in this case both are the same width, so just kill everything
   [data-ui-wrapper] & {
-    // width: auto;
-    // margin-left: 0;
-    // margin-right: 0;
-    // left: 0;
-    // right: 0;
-
     // if a specific width is nested in a default wrapper
     @each $name, $width in $layout-widths {
-      @include media('>#{$width}') {
-        @if ($name != 'default') {
+      // only create rules for widths that are bigger than the parent
+      // -> e.g. 'default' > 'wide'
+      @if (layout-w-difference('default', $name) < 0) {
+        @include media('>#{$width}') {
           &[data-ui-wrapper~='#{$name}'] {
-            @include wrapper-outcrop-variation($name);
+            @include _wrapper-outcrop-variation($name);
+          }
+        }
+      } @else {
+        // otherwise, reset it and make it act like a regular container
+        @if $name == 'default' {
+          #{_not-wrapper-variation()} {
+            @include _wrapper-outcrop-variation($name, $padding: 0);
+          }
+        } @else {
+          &[data-ui-wrapper~='#{$name}'] {
+            @include _wrapper-outcrop-variation($name, $padding: 0);
           }
         }
       }
@@ -90,14 +98,29 @@
     @if ($parent-name != 'default') {
       [data-ui-wrapper~='#{$parent-name}'] & {
         @each $child-name, $child-width in $layout-widths {
-          @include media('>#{$child-width}') {
-            @if($child-name == 'default') {
-              #{not-wrapper-variation()} {
-                @include wrapper-outcrop-variation($child-name, $parent-name);
+          // only create rules for widths that are bigger than the parent
+          // -> e.g. 'narrow' > 'wide'
+          @if (layout-w-difference($parent-name, $child-name) < 0) {
+            @include media('>#{$child-width}') {
+              @if($child-name == 'default') {
+                #{_not-wrapper-variation()} {
+                  @include _wrapper-outcrop-variation($child-name, $parent-name);
+                }
+              } @else {
+                &[data-ui-wrapper~='#{$child-name}'] {
+                  @include _wrapper-outcrop-variation($child-name, $parent-name);
+                }
+              }
+            }
+          } @else {
+            // otherwise, reset it and make it act like a regular container
+            @if $child-name == 'default' {
+              #{_not-wrapper-variation()} {
+                @include _wrapper-outcrop-variation($child-name, $parent-name, $padding: 0);
               }
             } @else {
               &[data-ui-wrapper~='#{$child-name}'] {
-                @include wrapper-outcrop-variation($child-name, $parent-name);
+                @include _wrapper-outcrop-variation($child-name, $parent-name, $padding: 0);
               }
             }
           }

--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -6,19 +6,26 @@
 @import '../config/layout_width';
 @import '../config/spacing';
 
-// create a selector list that includes all wrapper width variations with :not()
-// -> this addresses a specificity issue where [data-ui-wrapper~='outcrop'] selects
-//    all sizes, but we need to select only the 'default' size
-// -> can't find a way to automatically build this selector from the $layout-widths map,
-//    so have to hard code this for the moment. Update when new global widths are added to config.
-@function _not-wrapper-variation() {
-  @return #{&:not([data-ui-wrapper~='narrow']):not([data-ui-wrapper~='wide'])};
+// build a rule where all the wrapper width variations are chained in a :not() selector
+// -> needed to fix a specificity issue where [data-ui-wrapper~='outcrop'] selects all the
+//    other widths; this selects ONLY the default width
+@function _only-the-default-width() {
+  $selector: '&';
+
+  @each $name, $width in $layout-widths {
+    @if $name != 'default' {
+      $selector: $selector + ':not([data-ui-wrapper~=#{$name}])'
+    }
+  }
+
+  @return unquote($selector);
 }
 
 // create overrides for an 'outcrop' version of the wrapper at a given width
 // -> see 'outcrop' styles below
 @mixin _wrapper-outcrop-variation($width, $parent-width: 'default', $padding: 'none') {
   $margin: if(layout-w-difference($parent-width, $width) < 0, (layout-w-difference($parent-width, $width) / 2), auto);
+
   left: 0;
   margin-left: $margin;
   margin-right: $margin;
@@ -79,7 +86,7 @@
       } @else {
         // otherwise, reset it and make it act like a regular container
         @if $name == 'default' {
-          #{_not-wrapper-variation()} {
+          #{_only-the-default-width()} {
             @include _wrapper-outcrop-variation($name, $padding: 0);
           }
         } @else {
@@ -103,7 +110,7 @@
           @if (layout-w-difference($parent-name, $child-name) < 0) {
             @include media('>#{$child-width}') {
               @if($child-name == 'default') {
-                #{_not-wrapper-variation()} {
+                #{_only-the-default-width()} {
                   @include _wrapper-outcrop-variation($child-name, $parent-name);
                 }
               } @else {
@@ -115,7 +122,7 @@
           } @else {
             // otherwise, reset it and make it act like a regular container
             @if $child-name == 'default' {
-              #{_not-wrapper-variation()} {
+              #{_only-the-default-width()} {
                 @include _wrapper-outcrop-variation($child-name, $parent-name, $padding: 0);
               }
             } @else {

--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -14,7 +14,7 @@
 
   @each $name, $width in $layout-widths {
     @if $name != 'default' {
-      $selector: $selector + ':not([data-ui-wrapper~=#{$name}])'
+      $selector: $selector + ':not([data-ui-wrapper~=#{$name}])';
     }
   }
 

--- a/source/assets/stylesheets/config/_layout_width.scss
+++ b/source/assets/stylesheets/config/_layout_width.scss
@@ -5,7 +5,6 @@
 
 // width of main layout
 $layout-widths: (
-  'xnarrow': 480px,
   'narrow': 600px,
   'default': 750px,
   'wide': 1200px

--- a/source/assets/stylesheets/config/_layout_width.scss
+++ b/source/assets/stylesheets/config/_layout_width.scss
@@ -15,3 +15,7 @@ $layout-widths: (
 @function layout-w($w: 'default') {
   @return map-get($layout-widths, $w);
 }
+
+@function layout-w-difference($w1, $w2: 'default') {
+  @return (layout-w($w1) - layout-w($w2));
+}

--- a/source/components/_feature_image.erb
+++ b/source/components/_feature_image.erb
@@ -12,7 +12,7 @@
 
   # Private:
   props = [
-    width,
+    (width unless width == 'default'),
     'outcrop'
   ]
 

--- a/source/components/_feature_image.erb
+++ b/source/components/_feature_image.erb
@@ -5,11 +5,17 @@
   # Locals:
   # STRING source: the path or url of the image file
   alt ||= "" # STRING (optional): alt tag
+  width ||= 'wide' # STRING (optional): how wide the image should be
   padding ||= { y: 'wide' } # STRING/HASH (optional): padding classes
   borders ||= false # BOOLEAN (optional): add a border to the image
   classes ||= false # STRING (optional): additional utility classes
 
   # Private:
+  props = [
+    width,
+    'outcrop'
+  ]
+
   utils = [
     padding_classes(padding),
     't-align-center',
@@ -17,6 +23,6 @@
   ]
 %>
 
-<div data-ui-wrapper="wide outcrop"<%= class_list(utils) %>>
+<div data-ui-wrapper<%= props_list(props) %><%= class_list(utils) %>>
   <%= image_tag source, class: ('border' if borders), alt: alt %>
 </div>

--- a/source/work/ddh/02-approach.html.md.erb
+++ b/source/work/ddh/02-approach.html.md.erb
@@ -4,10 +4,10 @@ weight: 1
 project: DDH
 ---
 
-<%= component "feature_image", locals: { source: "work/ddh/assets/ddh-approach.svg" } %>
+<%= component 'feature_image', locals: { source: 'work/ddh/assets/ddh-approach.svg' } %>
 
 The Bank has over 10,000 employees with varying uses for development data. Our team engaged Bank staff and management in a series of qualitative knowledge collection activities to identify the range of end users’ needs relating to development data. This research involved over 550 stakeholder interactions, including  workshops, surveys and interviews of both internal stakeholders and external development data specialists. Feedback was collected from members of each of the Bank’s sub-units and supplemented by industry best-practice research and analysis of similar initiatives at other international organisations.
 
 We placed people at the center of strategy development to ensure our conclusions functioned in practice. Our conversations with stakeholders allowed us to understand both the day-to-day and long-term processes and needs of individuals, teams, and sectors in terms of data usage and interaction. These insights took th the form of strategy and structure recommendations for a future Development Data Hub accompanied by a series of recommendations for an effective knowledge-sharing, analysis, and cross-collaboration environment for development data users.
 
-<%= component "feature_image", locals: { source: "work/ddh/assets/ddh-approach-2.svg" } %>
+<%= component 'feature_image', locals: { source: 'work/ddh/assets/ddh-approach-2.svg', width: 'default' } %>

--- a/source/work/ddh/03-results.html.md.erb
+++ b/source/work/ddh/03-results.html.md.erb
@@ -6,4 +6,4 @@ project: DDH
 
 The Development Data Hub Strategy Report was presented to a committee of senior Bank directors, including the Managing Director and Chief Operating Officer, and the initiative was officially launched in November 2017.
 
-<%= component "feature_image", locals: { source: "assets/ddh-approach-3.png" } %>
+<%= component 'feature_image', locals: { source: 'assets/ddh-approach-3.png', width: 'default' } %>

--- a/source/work/ga/02-approach.html.md.erb
+++ b/source/work/ga/02-approach.html.md.erb
@@ -4,11 +4,11 @@ weight: 1
 project: GA
 ---
 
-<%= component "feature_image", locals: { source: "work/ga/assets/ga-approach.jpg" } %>
+<%= component 'feature_image', locals: { source: 'work/ga/assets/ga-approach.jpg', padding: { bottom: 'wide' } } %>
 
 From the very beginning, we’ve worked closely with the CGAP team, external consultants, and stakeholders on-location in the target countries (Ghana, Kenya, Malawi, Rwanda, Tanzania, Uganda, Zambia). The project began with a kickoff meeting to identify a shared vision of success and develop a project roadmap, which consisted of three major phases: Demo, Beta, and Launch.
 
 The Demo phase involved: a landscape analysis of the current training market for financial services and within financial service providers; design and collaboration workshops with financial service providers to facilitate discussion around e-learning needs and current practices; the development of Gateway Academy’s cloud-based online learning platform, which can be accessed in low-bandwidth contexts; and the onboarding of training service providers and future learners to the platform.
 
-<%= component "feature_image", locals: { source: "assets/ga-approach-2.jpg" } %>
-<%= component "feature_image", locals: { source: "assets/ga-vision.jpg" } %>
+<%= component 'feature_image', locals: { source: 'assets/ga-approach-2.jpg', padding: { top: 'wide' } } %>
+<%= component 'feature_image', locals: { source: 'assets/ga-vision.jpg', padding: { top: 'wide' }, width: 'default', borders: true } %>

--- a/source/work/ga/03-results.html.md.erb
+++ b/source/work/ga/03-results.html.md.erb
@@ -3,7 +3,7 @@ title: Results
 weight: 2
 project: GA
 ---
-The Demo phase was completed in July 2017. Participant feedback on the platform’s functionality and content  allowed our team to refine Gateway Academy for the Beta phase launch in February 2017. This phase will expand platform access to a greater number of financial service providers while providing more targeted content. To learn more, visit <%= link_to('Gateway Academy', 'https://gateway.academy', target: "_blank", ) %>
+The Demo phase was completed in July 2017. Participant feedback on the platform’s functionality and content  allowed our team to refine Gateway Academy for the Beta phase launch in February 2017. This phase will expand platform access to a greater number of financial service providers while providing more targeted content. To learn more, visit <%= link_to('Gateway Academy', 'https://gateway.academy', target: '_blank', ) %>
 
-<%= component "feature_image", locals: { source: "assets/ga-internal-1.png", borders: true } %>
-<%= component "feature_image", locals: { source: "assets/ga-internal-2.png", borders: true } %>
+<%= component 'feature_image', locals: { source: 'assets/ga-internal-1.png', borders: true, padding: { top: 'wide' } } %>
+<%= component 'feature_image', locals: { source: 'assets/ga-internal-2.png', borders: true, padding: { top: 'wide' } } %>

--- a/source/work/ppp/02-approach.html.md.erb
+++ b/source/work/ppp/02-approach.html.md.erb
@@ -4,7 +4,7 @@ weight: 1
 project: PPP
 ---
 
-<%= component "feature_image", locals: { source: "assets/ppp-strategy-2.png" } %>
+<%= component 'feature_image', locals: { source: 'assets/ppp-strategy-2.png', padding: { bottom: 'wide' }, width: 'narrow' } %>
 
 Due to the number of organisations involved in curating and sharing PPP resources, we developed communications tools and materials to keep all teams engaged and updated on progress. To engage stakeholders on a personal level and draw individual feedback, we also conducted interviews and facilitated sessions.  This communication network served as a feedback loop to build buy-in and incorporate ideas from different teams’ perspectives.
 

--- a/source/work/ppp/03-results.html.md.erb
+++ b/source/work/ppp/03-results.html.md.erb
@@ -6,5 +6,5 @@ project: PPP
 
 Our team aided the launch of the sites at PPP Days in London, where the Knowledge Lab was highlighted at a session dedicated to knowledge platforms. Integration with knowledge initiatives across additional organisations is ongoing.
 
-<%= component "feature_image", locals: { source: "assets/ppp-country-page.png", borders: true } %>
+<%= component "feature_image", locals: { source: "assets/ppp-country-page.png", borders: true, padding: { top: 'wide' } } %>
 


### PR DESCRIPTION
## Description
- set up layout width options for case study images. Pass in `width: [SIZE]` as a local. Available widths are `narrow`, `default`, and `wide`. Will default to `wide`.
- cleaned up spacing and sizes of existing case study images.

## Issues
- Resolves #41
- #43